### PR TITLE
Added section about docker images older node versions

### DIFF
--- a/content/BuildConfigurations.md
+++ b/content/BuildConfigurations.md
@@ -47,6 +47,12 @@ You will also have to define correct `publicDir`, here's list of default configu
 
 </div>
 
+### Using an Older Node Version
+
+By the default, the Fleek Docker images use the latest Node.js version available when applicable. It is possible to use an older Node version by applying the correct Docker tag.
+
+EG: To use Gatsby with Node 10, the Docker image is `fleek/gatsby:node-10`
+
 ### If you're using Gatsby
 
 You also need to have the `gatsby-plugin-ipfs` installed and configured in your `gatsby-config` file.

--- a/content/BuildConfigurations.md
+++ b/content/BuildConfigurations.md
@@ -53,10 +53,6 @@ By the default, the Fleek Docker images use the latest Node.js version available
 
 EG: To use Gatsby with Node 10, the Docker image is `fleek/gatsby:node-10`
 
-### If you're using Gatsby
-
-You also need to have the `gatsby-plugin-ipfs` installed and configured in your `gatsby-config` file.
-
 # Testing builds locally
 
 We're using docker containers to execute your builds, so you can test them locally with Docker. Here's a sample docker-compose.yml, we're using Verdaccio as a local npm proxy (it's not supported for production builds).

--- a/content/BuildConfigurations.md
+++ b/content/BuildConfigurations.md
@@ -47,7 +47,7 @@ You will also have to define correct `publicDir`, here's list of default configu
 
 </div>
 
-### Using an Older Node Version
+### Using a Docker Image with an Older Node Version
 
 By the default, the Fleek Docker images use the latest Node.js version available when applicable. It is possible to use an older Node version by applying the correct Docker tag.
 


### PR DESCRIPTION
-information about docker images and node version
-removed section about gatsby plug in for IPFS. This is not necessary. Also, it will be useless soon with the change in ipfs gateway urls.